### PR TITLE
[TASK] Add phpdocblock to describe array types for static code analyzer

### DIFF
--- a/src/Check.php
+++ b/src/Check.php
@@ -18,6 +18,9 @@ use CmsHealth\Definition\CheckInterface;
 
 class Check implements CheckInterface, \JsonSerializable
 {
+    /**
+     * @var array<CheckResult>
+     */
     private array $checkResults = [];
 
     public function __construct(

--- a/src/CheckCollection.php
+++ b/src/CheckCollection.php
@@ -25,7 +25,9 @@ class CheckCollection implements \JsonSerializable
     {
         foreach ($checks as $check) {
             $identifier = $check->getIdentifier();
-            if (!isset($this->checks[$identifier])) {
+            if ($identifier !== ''
+                && !isset($this->checks[$identifier])
+            ) {
                 // There is no check for the identifier, use the check directly.
                 $this->checks[$identifier] = $check;
                 continue;
@@ -38,6 +40,9 @@ class CheckCollection implements \JsonSerializable
         }
     }
 
+    /**
+     * @return array<non-empty-string, Check>
+     */
     public function getChecks(): array
     {
         return $this->checks;
@@ -48,6 +53,17 @@ class CheckCollection implements \JsonSerializable
         return array_keys($this->checks) !== [];
     }
 
+    /**
+     * @return array<non-empty-string, list<array{
+     *    componentId: string,
+     *    componentType: string,
+     *    status: string,
+     *    time: string,
+     *    output?: string,
+     *    observedValue?: string,
+     *    observedUnit?: string
+     *  }>>
+     */
     public function jsonSerialize(): array
     {
         $return = [];

--- a/tests/Unit/CheckResultTest.php
+++ b/tests/Unit/CheckResultTest.php
@@ -47,6 +47,7 @@ final class CheckResultTest extends TestCase
     {
         $dt = \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-19T01:23:45+00:00');
         $subject = $this->createSubject();
+        self::assertNotFalse($dt);
         self::assertSame($dt->getTimeStamp(), $subject->getTime()->getTimestamp());
     }
 
@@ -89,7 +90,7 @@ final class CheckResultTest extends TestCase
             'component-id',
             'system',
             CheckResultStatus::Fail,
-            \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-19T01:23:45+00:00'),
+            \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-19T01:23:45+00:00') ?: new \DateTime(),
             'value',
             'unit',
             'output',

--- a/tests/Unit/HealthCheckTest.php
+++ b/tests/Unit/HealthCheckTest.php
@@ -39,6 +39,7 @@ final class HealthCheckTest extends TestCase
     private function createSubject(): HealthCheck
     {
         $time = \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-19T01:23:45+00:00');
+        self::assertNotFalse($time);
         $check1 = new Check('package:check-one');
         $check1->addCheckResults(
             new CheckResult(


### PR DESCRIPTION
The used static code analyzer is quite picky on higher
levels regarding arrays and the iterable type.

This change adds some missing phpdoc block annotations
to make the shape of arrays more clear, not only for
phpstan but also for developers.
